### PR TITLE
Repackaged some things left outside and fixed OrderTest

### DIFF
--- a/src/main/java/com/develhope/spring/deals/models/Rental.java
+++ b/src/main/java/com/develhope/spring/deals/models/Rental.java
@@ -1,7 +1,7 @@
-package com.develhope.spring.model.user;
+package com.develhope.spring.deals.models;
 
+import com.develhope.spring.vehicles.models.Vehicle;
 import jakarta.persistence.*;
-import vehicle.Vehicle;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/src/main/java/com/develhope/spring/vehicles/optionals/enums/TypeOfWindows.java
+++ b/src/main/java/com/develhope/spring/vehicles/optionals/enums/TypeOfWindows.java
@@ -1,4 +1,4 @@
-package com.develhope.spring.vehicle.optionals.enums;
+package com.develhope.spring.vehicles.optionals.enums;
 
 public enum TypeOfWindows {
     BASIC,

--- a/src/main/java/com/develhope/spring/vehicles/optionals/models/Windows.java
+++ b/src/main/java/com/develhope/spring/vehicles/optionals/models/Windows.java
@@ -1,6 +1,6 @@
-package com.develhope.spring.vehicle.optionals.models;
+package com.develhope.spring.vehicles.optionals.models;
 
-import com.develhope.spring.vehicle.optionals.enums.TypeOfWindows;
+import com.develhope.spring.vehicles.optionals.enums.TypeOfWindows;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/develhope/spring/deals/models/OrderTest.java
+++ b/src/test/java/com/develhope/spring/deals/models/OrderTest.java
@@ -1,13 +1,11 @@
-package com.develhope.spring.model;
+package com.develhope.spring.deals.models;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import com.develhope.spring.deals.models.Order;
-import com.develhope.spring.deals.models.OrderStatus;
 import org.junit.jupiter.api.Test;
 
-class OrderTests {
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+public class OrderTest {
     @Test
     void testOrderInitialization() {
         Order order = new Order(true, OrderStatus.PENDING,  123);

--- a/src/test/java/com/develhope/spring/deals/models/RentalTest.java
+++ b/src/test/java/com/develhope/spring/deals/models/RentalTest.java
@@ -1,10 +1,8 @@
-package com.develhope.spring.model.user;
-import org.junit.jupiter.api.BeforeEach;
+package com.develhope.spring.deals.models;
+import com.develhope.spring.vehicles.models.Vehicle;
 import org.junit.jupiter.api.Test;
-import vehicle.Vehicle;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
L'OrderTest compiva un'azione strana a livello di packaging: era come se la classe fosse contenuta in sé stessa, mi chiedeva di cliccare su OrderTests.java per poter vedere OrderTests